### PR TITLE
fix: rename Namespace to ManagedNamespace to avoid K8s API conflict

### DIFF
--- a/configuration/composition.yaml
+++ b/configuration/composition.yaml
@@ -4,13 +4,13 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: namespaces.openportal.dev
+  name: managednamespaces.openportal.dev
   labels:
-    crossplane.io/xrd: namespaces.openportal.dev
+    crossplane.io/xrd: managednamespaces.openportal.dev
 spec:
   compositeTypeRef:
     apiVersion: openportal.dev/v1alpha1
-    kind: Namespace
+    kind: ManagedNamespace
   
   # Use Pipeline mode for composition functions
   mode: Pipeline
@@ -40,6 +40,7 @@ spec:
                 {{- end }}
               annotations:
                 gotemplating.fn.crossplane.io/composition-resource-name: namespace-resource
+                gotemplating.fn.crossplane.io/ready: "True"
                 crossplane.io/composite-resource-name: {{ .observed.composite.resource.metadata.name }}
                 {{- range $key, $value := .observed.composite.resource.spec.annotations }}
                 {{ $key }}: {{ $value | quote }}

--- a/configuration/xrd.yaml
+++ b/configuration/xrd.yaml
@@ -5,7 +5,7 @@
 apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
-  name: namespaces.openportal.dev
+  name: managednamespaces.openportal.dev
   labels:
     terasky.backstage.io/generate-form: "true"
     terasky.backstage.io/version: "v1.1.0"
@@ -19,8 +19,8 @@ spec:
   scope: Cluster # Namespaces are cluster-scoped resources
   group: openportal.dev
   names:
-    kind: Namespace
-    plural: namespaces
+    kind: ManagedNamespace
+    plural: managednamespaces
   versions:
     - name: v1alpha1
       served: true

--- a/examples/basic-namespace.yaml
+++ b/examples/basic-namespace.yaml
@@ -1,9 +1,8 @@
 # Example: Basic namespace creation
 apiVersion: openportal.dev/v1alpha1
-kind: Namespace
+kind: ManagedNamespace
 metadata:
   name: demo-basic
-  namespace: default  # XR can be created in any namespace (v2 style)
 spec:
   name: demo-basic
   team: platform-team

--- a/examples/team-namespace.yaml
+++ b/examples/team-namespace.yaml
@@ -1,10 +1,9 @@
 # Example: Team namespace with labels and annotations
 # Note: This template only creates the namespace itself, keeping it simple
 apiVersion: openportal.dev/v1alpha1
-kind: Namespace
+kind: ManagedNamespace
 metadata:
   name: team-backend
-  namespace: default  # XR can be created in any namespace (v2 style)
 spec:
   name: backend-services
   team: backend-team


### PR DESCRIPTION
## Summary
- Renamed XRD kind from `Namespace` to `ManagedNamespace` to avoid conflicts with core Kubernetes API
- Added proper readiness annotation for native K8s resources
- Updated all configuration and example files

## Problem
The original XRD used `kind: Namespace` which conflicted with Kubernetes' core Namespace API. This caused issues where:
- `kubectl describe namespace.openportal.dev <name>` would fail with "resource not found"
- kubectl would default to the core v1 Namespace API instead of our custom resource
- XRs couldn't be properly managed or described

## Solution
- Changed the kind to `ManagedNamespace` (plural: `managednamespaces`)
- Added `gotemplating.fn.crossplane.io/ready: "True"` annotation to mark native K8s resources as ready
- Updated all references in composition and example files

## Test Plan
- [x] Applied updated XRD and Composition
- [x] Created ManagedNamespace XRs from examples
- [x] Verified XRs show as SYNCED and READY
- [x] Confirmed `kubectl describe managednamespace` works correctly
- [x] Validated actual Kubernetes namespaces are created with proper labels/annotations

Refers to https://github.com/open-service-portal/portal-workspace/issues/63

🤖 Generated with [Claude Code](https://claude.ai/code)