### PR TITLE
feat: enforce system namespace for ManagedNamespace XRs

### DIFF
--- a/configuration/xrd.yaml
+++ b/configuration/xrd.yaml
@@ -15,6 +15,14 @@ metadata:
     openportal.dev/tags: "namespace,kubernetes,core"
     openportal.dev/description: "Creates and manages Kubernetes namespaces with labels and annotations"
     openportal.dev/icon: "folder"
+    # Backstage publishing configuration - enforces system namespace
+    terasky.backstage.io/publish-phase: |
+      gitRepo: "github.com?owner=open-service-portal&repo=catalog-orders"
+      gitBranch: "main"
+      gitLayout: "cluster-scoped"
+      basePath: "system/ManagedNamespace"
+      fixedNamespace: "system"
+      createPr: true
 spec:
   scope: Namespaced # Changed to Namespaced - XRs will live in system namespace
   group: openportal.dev


### PR DESCRIPTION
## Summary

Enforces that all ManagedNamespace XRs must be created in the `system` namespace, both in Git and Kubernetes.

## Changes

### XRD Enhancements
- Added `terasky.backstage.io/publish-phase` annotations
- Set `fixedNamespace: system` to force namespace in metadata
- Set `basePath: system/ManagedNamespace` for consistent Git structure

## Benefits

### Consistency
- All ManagedNamespace XRs will be in the same namespace
- Git structure matches Kubernetes structure
- No confusion about where infrastructure resources live

### Safety
- Users cannot accidentally create ManagedNamespace XRs in wrong namespaces
- Prevents namespace pollution
- Maintains clear separation between infrastructure and application resources

### GitOps Compatibility
- Flux can reliably apply resources with correct namespace
- No more "namespace not specified" errors
- Server-side apply works correctly

## How It Works

When Backstage reads the XRD with publishPhase annotations:
1. It automatically sets the Git path to `<cluster>/system/ManagedNamespace/`
2. It forces `metadata.namespace: system` in all created XRs
3. Users don't need to (and can't) specify a different namespace

## Testing

1. Deploy this XRD update:
   ```bash
   kubectl apply -f configuration/xrd.yaml
   ```

2. Create a ManagedNamespace via Backstage
3. Verify it's created in:
   - Git: `catalog-orders/<cluster>/system/ManagedNamespace/`
   - K8s: `kubectl get managednamespaces -n system`

## Breaking Changes

None - this is a new enforcement that doesn't affect existing XRs.

## Related

- portal-workspace PR #86 - Created system namespace
- catalog PR #33 - Updated to template v2.1.0
- Original issue: API server cache inconsistency with cluster-scoped XRs